### PR TITLE
Fix compilation with Dune 2.7.0

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (library
   (public_name zxcvbn)
   (c_names zxcvbn_stubs zxcvbn)
-  (c_flags (:standard "-I ."))
+  (c_flags (:standard -I .))
   (preprocess
     (pps
       ppx_deriving.std

--- a/zxcvbn.opam
+++ b/zxcvbn.opam
@@ -13,7 +13,7 @@ run-test: [
   ["dune" "runtest" "-p" name "-j" jobs]
 ]
 depends: [
-  "dune" {build & >= "1.4.0"}
+  "dune" {>= "1.4.0"}
   "ocaml" {>= "4.04.0"}
   "ounit" {with-test}
   "ppx_deriving" {>= "4.0" & < "5.0"}


### PR DESCRIPTION
This makes it possible to install this package with Dune 2.7.0.

Without this, the following error occurs:

```
zxcvbn.c:25:10: fatal error: zxcvbn.h: No such file or directory
   25 | #include <zxcvbn.h>
      |          ^~~~~~~~~~
```